### PR TITLE
Revert "fix: do not add static 'config' object on conditional impls"

### DIFF
--- a/jsonschema-module-expressive-annotations/src/main/java/io/github/axonivy/json/schema/impl/ImplementationTypesProvider.java
+++ b/jsonschema-module-expressive-annotations/src/main/java/io/github/axonivy/json/schema/impl/ImplementationTypesProvider.java
@@ -56,12 +56,13 @@ public class ImplementationTypesProvider implements CustomDefinitionProviderV2 {
     var props = propertiesOf(context, std);
     props.set(impls.type(), craftTypeConsts(context, registry));
 
+    var container = props.putObject(impls.container());
     if (!conditional) {
-      var container = props.putObject(impls.container());
       container.setAll(craftAnyOf(context, registry.types()));
       return new CustomDefinition(std, false);
     }
 
+    container.put("type", "object"); //vs-code needs a generic block for validation
     return conditional(context, impls, registry)
       .toDefinition(()->std)
       .map(node -> new CustomDefinition(node, false))

--- a/jsonschema-module-expressive-annotations/src/test/java/io/github/axonivy/json/schema/tests/TestImplementationTypes.java
+++ b/jsonschema-module-expressive-annotations/src/test/java/io/github/axonivy/json/schema/tests/TestImplementationTypes.java
@@ -40,10 +40,7 @@ class TestImplementationTypes {
     var propNames = namesOf(props);
     assertThat(propNames)
       .as("virtual properties injected by using the AllImplementations annotation")
-      .contains("type");
-    assertThat(propNames)
-      .as("config is not statically available; it's conditionally available based on the 'type'")
-      .doesNotContain("config");
+      .contains("type", "config");
     assertThat(propNames)
       .as("enriched with properties from a 'base' type")
       .contains("common");


### PR DESCRIPTION
This reverts commit 8045ed4e2c3a41be45c861676d4a49764f14ec40.

failed attempt; actually VS-code likes these if/else constructs combined with an empty container for the yet not strictly defined content.